### PR TITLE
Allowed registrants to set that they've been to 0 hackathons.

### DIFF
--- a/apps/web/src/validators/shared/RegisterForm.ts
+++ b/apps/web/src/validators/shared/RegisterForm.ts
@@ -77,7 +77,7 @@ export const RegisterFormValidator = z.object({
 	]),
 	hackathonsAttended: z
 		.number()
-		.positive({ message: "Value must be positive" })
+		.nonnegative({ message: "Value must be non-negative" })
 		.int({ message: "Value must be an integer" })
 		.or(z.string())
 		.pipe(


### PR DESCRIPTION
Fixes #22 

Only change needed was setting the Zod validation on `hackathonsAttended` to `nonnegative` instead of `positive` .