### PR TITLE
Add Approved Users

### DIFF
--- a/apps/web/src/actions/admin/user-actions.ts
+++ b/apps/web/src/actions/admin/user-actions.ts
@@ -28,3 +28,19 @@ export const updateRole = adminAction(
 		return { success: true };
 	},
 );
+
+export const setUserApproval = adminAction(
+	z.object({
+		userIDToUpdate: z.string().min(1),
+		approved: z.boolean(),
+	}),
+
+	async ({ userIDToUpdate, approved }, { user, userId }) => {
+		await db
+			.update(users)
+			.set({ approved })
+			.where(eq(users.clerkID, userIDToUpdate));
+		revalidatePath(`/admin/users/${userIDToUpdate}`);
+		return { success: true };
+	},
+);

--- a/apps/web/src/app/admin/users/[slug]/page.tsx
+++ b/apps/web/src/app/admin/users/[slug]/page.tsx
@@ -67,7 +67,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
 						currPermision={user.role}
 						userID={user.clerkID}
 					/>
-					{c.featureFlags.core.requireUsersApproval && (
+					{(c.featureFlags.core.requireUsersApproval as boolean) && (
 						<ApproveUserButton
 							userIDToUpdate={user.clerkID}
 							currentApproval={user.approved}

--- a/apps/web/src/app/admin/users/[slug]/page.tsx
+++ b/apps/web/src/app/admin/users/[slug]/page.tsx
@@ -17,6 +17,8 @@ import {
 import { auth } from "@clerk/nextjs";
 import { notFound } from "next/navigation";
 import { isUserAdmin } from "@/lib/utils/server/admin";
+import ApproveUserButton from "@/components/admin/users/ApproveUserButton";
+import c from "config";
 
 export default async function Page({ params }: { params: { slug: string } }) {
 	const { userId } = auth();
@@ -44,7 +46,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
 
 	return (
 		<main className="mx-auto max-w-5xl pt-44">
-			<div className="mb-5 grid w-full grid-cols-2">
+			<div className="mb-5 grid w-full grid-cols-3">
 				<div className="flex items-center">
 					<div>
 						<h2 className="flex items-center gap-x-2 text-3xl font-bold tracking-tight">
@@ -54,7 +56,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
 						{/* <p className="text-sm text-muted-foreground">{users.length} Total Users</p> */}
 					</div>
 				</div>
-				<div className="flex items-center justify-end gap-2">
+				<div className="col-span-2 flex items-center justify-end gap-2">
 					<Link href={`/@${user.hackerTag}`} target="_blank">
 						<Button variant={"outline"}>Hacker Profile</Button>
 					</Link>
@@ -65,6 +67,12 @@ export default async function Page({ params }: { params: { slug: string } }) {
 						currPermision={user.role}
 						userID={user.clerkID}
 					/>
+					{c.featureFlags.core.requireUsersApproval && (
+						<ApproveUserButton
+							userIDToUpdate={user.clerkID}
+							currentApproval={user.approved}
+						/>
+					)}
 				</div>
 			</div>
 			<div className="mt-20 grid min-h-[500px] w-full grid-cols-3">

--- a/apps/web/src/app/dash/layout.tsx
+++ b/apps/web/src/app/dash/layout.tsx
@@ -32,7 +32,7 @@ export default async function DashLayout({ children }: DashLayoutProps) {
 	if (!user) return redirect("/register");
 
 	if (
-		c.featureFlags.core.requireUsersApproval === true &&
+		(c.featureFlags.core.requireUsersApproval as boolean) === true &&
 		user.approved === false &&
 		user.role === "hacker"
 	) {

--- a/apps/web/src/app/discord-verify/page.tsx
+++ b/apps/web/src/app/discord-verify/page.tsx
@@ -44,7 +44,7 @@ export default async function Page({
 	}
 
 	if (
-		c.featureFlags.core.requireUsersApproval === true &&
+		(c.featureFlags.core.requireUsersApproval as boolean) === true &&
 		user.approved === false &&
 		user.role === "hacker"
 	) {

--- a/apps/web/src/app/discord-verify/page.tsx
+++ b/apps/web/src/app/discord-verify/page.tsx
@@ -43,6 +43,14 @@ export default async function Page({
 		return redirect("/register");
 	}
 
+	if (
+		c.featureFlags.core.requireUsersApproval === true &&
+		user.approved === false &&
+		user.role === "hacker"
+	) {
+		return redirect("/i/approval");
+	}
+
 	if (user.discordVerification) {
 		await db
 			.update(discordVerification)

--- a/apps/web/src/app/i/approval/page.tsx
+++ b/apps/web/src/app/i/approval/page.tsx
@@ -1,0 +1,30 @@
+import c from "config";
+import Link from "next/link";
+import { Button } from "@/components/shadcn/ui/button";
+
+export default function Page() {
+	return (
+		<main className="mx-auto flex min-h-screen w-full max-w-5xl flex-col items-center justify-center">
+			<div className="max-w-screen fixed left-1/2 top-[calc(50%+7rem)] h-[40vh] w-[800px] -translate-x-1/2 -translate-y-1/2 scale-150 overflow-x-hidden bg-hackathon opacity-30 blur-[100px] will-change-transform"></div>
+			<h1 className="mb-10 text-6xl font-extrabold text-hackathon dark:bg-gradient-to-t dark:from-hackathon/80 dark:to-white dark:bg-clip-text dark:text-transparent md:text-8xl">
+				{c.hackathonName}
+			</h1>
+			<div className="relative flex aspect-video w-full max-w-[500px] flex-col items-center justify-center rounded-xl bg-white p-5 backdrop-blur transition dark:bg-white/[0.08]">
+				<h1 className="flex items-center gap-x-2 text-2xl font-bold text-green-500">
+					{/* <CheckCircleIcon /> */}
+					Thanks for registering!
+				</h1>
+				<p className="pb-10 pt-5 text-center">
+					Your account is awaiting approval.
+					<br />
+					You will be notified when it is approved!
+				</p>
+				<Link href={"/"}>
+					<Button>Go Home</Button>
+				</Link>
+			</div>
+		</main>
+	);
+}
+
+export const runtime = "edge";

--- a/apps/web/src/app/rsvp/page.tsx
+++ b/apps/web/src/app/rsvp/page.tsx
@@ -37,6 +37,14 @@ export default async function RsvpPage({
 		return redirect("/register");
 	}
 
+	if (
+		c.featureFlags.core.requireUsersApproval === true &&
+		user.approved === false &&
+		user.role === "hacker"
+	) {
+		return redirect("/i/approval");
+	}
+
 	const rsvpEnabled = await kv.get("config:registration:allowRSVPs");
 
 	// TODO: fix type jank here

--- a/apps/web/src/app/rsvp/page.tsx
+++ b/apps/web/src/app/rsvp/page.tsx
@@ -38,7 +38,7 @@ export default async function RsvpPage({
 	}
 
 	if (
-		c.featureFlags.core.requireUsersApproval === true &&
+		(c.featureFlags.core.requireUsersApproval as boolean) === true &&
 		user.approved === false &&
 		user.role === "hacker"
 	) {

--- a/apps/web/src/components/admin/users/ApproveUserButton.tsx
+++ b/apps/web/src/components/admin/users/ApproveUserButton.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Button } from "@/components/shadcn/ui/button";
+import { useAction } from "next-safe-action/hook";
+import { setUserApproval } from "@/actions/admin/user-actions";
+import { toast } from "sonner";
+
+interface ApproveUserButtonProps {
+	userIDToUpdate: string;
+	currentApproval: boolean;
+}
+
+export default function ApproveUserButton({
+	userIDToUpdate,
+	currentApproval,
+}: ApproveUserButtonProps) {
+	const { execute, status } = useAction(setUserApproval, {
+		onSuccess: () => {
+			toast.dismiss();
+			console.log("Success");
+			toast.success(`User ${currentApproval ? "Un-a" : "A"}pproved!`);
+		},
+		onError: (e) => {
+			toast.dismiss();
+			console.log("Error", e);
+			toast.error(
+				"An error occurred while changing user approval. Please try again.",
+			);
+		},
+	});
+
+	return (
+		<Button
+			onClick={() => {
+				toast.loading("Changing user approval...");
+				execute({ userIDToUpdate, approved: !currentApproval });
+			}}
+			variant={"outline"}
+			disabled={status === "executing"}
+		>
+			{currentApproval ? "Un-a" : "A"}pprove User
+		</Button>
+	);
+}

--- a/packages/config/hackkit.config.ts
+++ b/packages/config/hackkit.config.ts
@@ -147,7 +147,7 @@ export default {
 	maxTeamSize: 4,
 	featureFlags: {
 		core: {
-			requireUsersApproval: false,
+			requireUsersApproval: true,
 		},
 	},
 } as const;

--- a/packages/config/hackkit.config.ts
+++ b/packages/config/hackkit.config.ts
@@ -147,7 +147,7 @@ export default {
 	maxTeamSize: 4,
 	featureFlags: {
 		core: {
-			requireUsersApproval: true,
+			requireUsersApproval: false,
 		},
 	},
 } as const;

--- a/packages/config/hackkit.config.ts
+++ b/packages/config/hackkit.config.ts
@@ -145,6 +145,11 @@ export default {
 		},
 	},
 	maxTeamSize: 4,
+	featureFlags: {
+		core: {
+			requireUsersApproval: false,
+		},
+	},
 } as const;
 
 // Its important that this is kept in sync with the database schema.

--- a/packages/db/drizzle/0014_known_norman_osborn.sql
+++ b/packages/db/drizzle/0014_known_norman_osborn.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "users" ADD COLUMN "approved" boolean DEFAULT false NOT NULL;

--- a/packages/db/drizzle/meta/0014_snapshot.json
+++ b/packages/db/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1068 @@
+{
+  "id": "ad1b5139-ce4c-4c3b-9beb-56fd1f3aac91",
+  "prevId": "79fab874-3e01-446c-a715-5bafdde1db92",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.chats": {
+      "name": "chats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "chat_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_ticket_id_tickets_id_fk": {
+          "name": "chats_ticket_id_tickets_id_fk",
+          "tableFrom": "chats",
+          "tableTo": "tickets",
+          "columnsFrom": [
+            "ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.chats_to_users": {
+      "name": "chats_to_users",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "chats_to_users_chat_id_chats_id_fk": {
+          "name": "chats_to_users_chat_id_chats_id_fk",
+          "tableFrom": "chats_to_users",
+          "tableTo": "chats",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "chats_to_users_user_id_users_clerk_id_fk": {
+          "name": "chats_to_users_user_id_users_clerk_id_fk",
+          "tableFrom": "chats_to_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "clerk_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "chats_to_users_user_id_chat_id_pk": {
+          "name": "chats_to_users_user_id_chat_id_pk",
+          "columns": [
+            "user_id",
+            "chat_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.discord_verification": {
+      "name": "discord_verification",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_user_tag": {
+          "name": "discord_user_tag",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_profile_photo": {
+          "name": "discord_profile_photo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_name": {
+          "name": "discord_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "discord_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "guild": {
+          "name": "guild",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.error_log": {
+      "name": "error_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "events_id_unique": {
+          "name": "events_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        }
+      }
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "presigned_url": {
+          "name": "presigned_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "validated": {
+          "name": "validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "files_id_unique": {
+          "name": "files_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "files_key_unique": {
+          "name": "files_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      }
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "invitee_id": {
+          "name": "invitee_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "invite_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "invites_invitee_id_team_id_pk": {
+          "name": "invites_invitee_id_team_id_pk",
+          "columns": [
+            "invitee_id",
+            "team_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.profile_data": {
+      "name": "profile_data",
+      "schema": "",
+      "columns": {
+        "hacker_tag": {
+          "name": "hacker_tag",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(60)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pronouns": {
+          "name": "pronouns",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skills": {
+          "name": "skills",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "profile_photo": {
+          "name": "profile_photo",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profile_data_hacker_tag_unique": {
+          "name": "profile_data_hacker_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hacker_tag"
+          ]
+        }
+      }
+    },
+    "public.registration_data": {
+      "name": "registration_data",
+      "schema": "",
+      "columns": {
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "race": {
+          "name": "race",
+          "type": "varchar(75)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ethnicity": {
+          "name": "ethnicity",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_mlh_code_of_conduct": {
+          "name": "accepted_mlh_code_of_conduct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shared_data_with_mlh": {
+          "name": "shared_data_with_mlh",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wants_to_receive_mlh_emails": {
+          "name": "wants_to_receive_mlh_emails",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university": {
+          "name": "university",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major": {
+          "name": "major",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_id": {
+          "name": "short_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level_of_study": {
+          "name": "level_of_study",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hackathons_attended": {
+          "name": "hackathons_attended",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "software_experience": {
+          "name": "software_experience",
+          "type": "varchar(25)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heard_from": {
+          "name": "heard_from",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shirt_size": {
+          "name": "shirt_size",
+          "type": "varchar(5)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diet_restrictions": {
+          "name": "diet_restrictions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accommodation_note": {
+          "name": "accommodation_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github": {
+          "name": "github",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personal_website": {
+          "name": "personal_website",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resume": {
+          "name": "resume",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'https://static.acmutsa.org/No%20Resume%20Provided.pdf'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "registration_data_clerk_id_unique": {
+          "name": "registration_data_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        }
+      }
+    },
+    "public.scans": {
+      "name": "scans",
+      "schema": "",
+      "columns": {
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scans_user_id_event_id_pk": {
+          "name": "scans_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(50)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo": {
+          "name": "photo",
+          "type": "varchar(400)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "devpost_url": {
+          "name": "devpost_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_id_unique": {
+          "name": "teams_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id"
+          ]
+        },
+        "teams_tag_unique": {
+          "name": "teams_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tag"
+          ]
+        }
+      }
+    },
+    "public.tickets": {
+      "name": "tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ticket_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'awaiting'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tickets_to_users": {
+      "name": "tickets_to_users",
+      "schema": "",
+      "columns": {
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tickets_to_users_ticket_id_tickets_id_fk": {
+          "name": "tickets_to_users_ticket_id_tickets_id_fk",
+          "tableFrom": "tickets_to_users",
+          "tableTo": "tickets",
+          "columnsFrom": [
+            "ticket_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tickets_to_users_user_id_users_clerk_id_fk": {
+          "name": "tickets_to_users_user_id_users_clerk_id_fk",
+          "tableFrom": "tickets_to_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "clerk_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tickets_to_users_user_id_ticket_id_pk": {
+          "name": "tickets_to_users_user_id_ticket_id_pk",
+          "columns": [
+            "user_id",
+            "ticket_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hacker_tag": {
+          "name": "hacker_tag",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registration_complete": {
+          "name": "registration_complete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "has_searchable_profile": {
+          "name": "has_searchable_profile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "group": {
+          "name": "group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'hacker'"
+        },
+        "checkin_timestamp": {
+          "name": "checkin_timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "checked_in": {
+          "name": "checked_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rsvp": {
+          "name": "rsvp",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "approved": {
+          "name": "approved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_hacker_tag_unique": {
+          "name": "users_hacker_tag_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hacker_tag"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.chat_type": {
+      "name": "chat_type",
+      "schema": "public",
+      "values": [
+        "ticket"
+      ]
+    },
+    "public.discord_status": {
+      "name": "discord_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "expired",
+        "accepted",
+        "rejected"
+      ]
+    },
+    "public.type": {
+      "name": "type",
+      "schema": "public",
+      "values": [
+        "generic",
+        "resume"
+      ]
+    },
+    "public.invite_status": {
+      "name": "invite_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted",
+        "declined"
+      ]
+    },
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": [
+        "hacker",
+        "volunteer",
+        "mentor",
+        "mlh",
+        "admin",
+        "super_admin"
+      ]
+    },
+    "public.ticket_status": {
+      "name": "ticket_status",
+      "schema": "public",
+      "values": [
+        "awaiting",
+        "in_progress",
+        "completed"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1721066710921,
       "tag": "0013_tidy_payback",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1721626835938,
+      "tag": "0014_known_norman_osborn",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/schema.ts
+++ b/packages/db/schema.ts
@@ -78,6 +78,7 @@ export const users = pgTable("users", {
 	points: integer("points").notNull().default(0),
 	checkedIn: boolean("checked_in").notNull().default(false),
 	rsvp: boolean("rsvp").notNull().default(false),
+	approved: boolean("approved").notNull().default(false),
 });
 
 export const userRelations = relations(users, ({ one, many }) => ({


### PR DESCRIPTION
Adds user approval that can be toggled via the HackKit config. Admins may approve users on a user-by-user basis. Unapproved users are redirected to `/i/approval` which thanks them for registering and asks that they await being approved.

Completes https://linear.app/acmutsa/issue/HK-130/add-optional-user-approval