### PR TITLE
Fix Registration Form and Uploads 

### DIFF
--- a/apps/web/src/components/registration/RegisterForm.tsx
+++ b/apps/web/src/components/registration/RegisterForm.tsx
@@ -59,8 +59,6 @@ interface RegisterFormProps {
 export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 	const { isLoaded, userId } = useAuth();
 	const router = useRouter();
-	
-
 
 	const form = useForm<z.infer<typeof RegisterFormValidator>>({
 		resolver: zodResolver(RegisterFormValidator),
@@ -101,7 +99,7 @@ export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 	const [isLoading, setIsLoading] = useState(false);
 	const universityValue = form.watch("university");
 	const bioValue = form.watch("bio");
-	
+
 	useEffect(() => {
 		if (universityValue != c.localUniversityName.toLowerCase()) {
 			form.setValue("shortID", "NOT_LOCAL_SCHOOL");
@@ -131,7 +129,7 @@ export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 		}
 
 		let resume: string = c.noResumeProvidedURL;
-		
+
 		if (uploadedFile) {
 			const fileLocation = `${c.hackathonName}/resume/${uploadedFile.name}`;
 			const newBlob = await put(fileLocation, uploadedFile, {
@@ -511,7 +509,7 @@ export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 								render={({ field }) => (
 									<FormItem className="col-span-2 flex flex-col">
 										<FormLabel>University</FormLabel>
-										<Popover >
+										<Popover>
 											<PopoverTrigger asChild>
 												<FormControl>
 													<Button
@@ -592,7 +590,7 @@ export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 								render={({ field }) => (
 									<FormItem className="col-span-2 flex flex-col">
 										<FormLabel>Major</FormLabel>
-										<Popover >
+										<Popover>
 											<PopoverTrigger asChild>
 												<FormControl>
 													<Button

--- a/apps/web/src/components/registration/RegisterForm.tsx
+++ b/apps/web/src/components/registration/RegisterForm.tsx
@@ -32,6 +32,7 @@ import {
 	CommandGroup,
 	CommandInput,
 	CommandItem,
+	CommandList,
 } from "@/components/shadcn/ui/command";
 import {
 	Popover,
@@ -58,6 +59,9 @@ interface RegisterFormProps {
 export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 	const { isLoaded, userId } = useAuth();
 	const router = useRouter();
+	
+
+
 	const form = useForm<z.infer<typeof RegisterFormValidator>>({
 		resolver: zodResolver(RegisterFormValidator),
 		defaultValues: {
@@ -95,10 +99,9 @@ export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 	const [uploadedFile, setUploadedFile] = useState<File | null>(null);
 	const [skills, setSkills] = useState<Tag[]>([]);
 	const [isLoading, setIsLoading] = useState(false);
-
 	const universityValue = form.watch("university");
 	const bioValue = form.watch("bio");
-
+	
 	useEffect(() => {
 		if (universityValue != c.localUniversityName.toLowerCase()) {
 			form.setValue("shortID", "NOT_LOCAL_SCHOOL");
@@ -128,9 +131,10 @@ export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 		}
 
 		let resume: string = c.noResumeProvidedURL;
-
+		
 		if (uploadedFile) {
-			const newBlob = await put(uploadedFile.name, uploadedFile, {
+			const fileLocation = `${c.hackathonName}/resume/${uploadedFile.name}`;
+			const newBlob = await put(fileLocation, uploadedFile, {
 				access: "public",
 				handleBlobUploadUrl: "/api/upload/resume/register",
 			});
@@ -507,7 +511,7 @@ export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 								render={({ field }) => (
 									<FormItem className="col-span-2 flex flex-col">
 										<FormLabel>University</FormLabel>
-										<Popover>
+										<Popover >
 											<PopoverTrigger asChild>
 												<FormControl>
 													<Button
@@ -522,7 +526,7 @@ export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 														{field.value
 															? schools.find(
 																	(school) =>
-																		school.toLowerCase() ===
+																		school ===
 																		field.value,
 																)
 															: "Select a University"}
@@ -533,40 +537,48 @@ export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 											<PopoverContent className="no-scrollbar max-h-[400px] w-[250px] overflow-y-auto p-0">
 												<Command>
 													<CommandInput placeholder="Search university..." />
-													<CommandEmpty>
-														No university found.
-													</CommandEmpty>
-													<CommandGroup>
-														{schools.map(
-															(school) => (
-																<CommandItem
-																	value={
-																		school
-																	}
-																	key={school}
-																	onSelect={(
-																		value,
-																	) => {
-																		form.setValue(
-																			"university",
+													<CommandList>
+														<CommandEmpty>
+															No university found.
+														</CommandEmpty>
+														<CommandGroup>
+															{schools.map(
+																(school) => (
+																	<CommandItem
+																		value={
+																			school
+																		}
+																		key={
+																			school
+																		}
+																		onSelect={(
 																			value,
-																		);
-																	}}
-																	className="cursor-pointer"
-																>
-																	<Check
-																		className={`mr-2 h-4 w-4 ${
-																			school.toLowerCase() ===
-																			field.value
-																				? "block"
-																				: "hidden"
-																		} `}
-																	/>
-																	{school}
-																</CommandItem>
-															),
-														)}
-													</CommandGroup>
+																		) => {
+																			console.log(
+																				"value changed to: ",
+																				value,
+																			);
+																			form.setValue(
+																				"university",
+																				value,
+																			);
+																		}}
+																		className="cursor-pointer"
+																	>
+																		<Check
+																			className={`mr-2 h-4 w-4 ${
+																				school.toLowerCase() ===
+																				field.value
+																					? "block"
+																					: "hidden"
+																			} `}
+																		/>
+																		{school}
+																	</CommandItem>
+																),
+															)}
+														</CommandGroup>
+													</CommandList>
 												</Command>
 											</PopoverContent>
 										</Popover>
@@ -580,7 +592,7 @@ export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 								render={({ field }) => (
 									<FormItem className="col-span-2 flex flex-col">
 										<FormLabel>Major</FormLabel>
-										<Popover>
+										<Popover >
 											<PopoverTrigger asChild>
 												<FormControl>
 													<Button
@@ -595,7 +607,7 @@ export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 														{field.value
 															? majors.find(
 																	(major) =>
-																		major.toLowerCase() ===
+																		major ===
 																		field.value,
 																)
 															: "Select a Major"}
@@ -606,36 +618,44 @@ export default function RegisterForm({ defaultEmail }: RegisterFormProps) {
 											<PopoverContent className="no-scrollbar max-h-[400px] w-[250px] overflow-y-auto p-0">
 												<Command>
 													<CommandInput placeholder="Search major..." />
-													<CommandEmpty>
-														No major found.
-													</CommandEmpty>
-													<CommandGroup>
-														{majors.map((major) => (
-															<CommandItem
-																value={major}
-																key={major}
-																onSelect={(
-																	value,
-																) => {
-																	form.setValue(
-																		"major",
-																		value,
-																	);
-																}}
-																className="cursor-pointer"
-															>
-																<Check
-																	className={`mr-2 h-4 w-4 overflow-hidden ${
-																		major.toLowerCase() ===
-																		field.value
-																			? "block"
-																			: "hidden"
-																	} `}
-																/>
-																{major}
-															</CommandItem>
-														))}
-													</CommandGroup>
+													<CommandList>
+														<CommandEmpty>
+															No major found.
+														</CommandEmpty>
+														<CommandGroup>
+															{majors.map(
+																(major) => (
+																	<CommandItem
+																		value={
+																			major
+																		}
+																		key={
+																			major
+																		}
+																		onSelect={(
+																			value,
+																		) => {
+																			form.setValue(
+																				"major",
+																				value,
+																			);
+																		}}
+																		className="cursor-pointer"
+																	>
+																		<Check
+																			className={`mr-2 h-4 w-4 overflow-hidden ${
+																				major.toLowerCase() ===
+																				field.value
+																					? "block"
+																					: "hidden"
+																			} `}
+																		/>
+																		{major}
+																	</CommandItem>
+																),
+															)}
+														</CommandGroup>
+													</CommandList>
 												</Command>
 											</PopoverContent>
 										</Popover>

--- a/apps/web/src/components/shadcn/ui/command.tsx
+++ b/apps/web/src/components/shadcn/ui/command.tsx
@@ -120,13 +120,13 @@ const CommandItem = React.forwardRef<
 	<CommandPrimitive.Item
 		ref={ref}
 		className={cn(
-			"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+			"relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground",
 			className,
 		)}
 		{...props}
 	/>
 ));
-
+// data-[disabled='true']:pointer-events-none data-[disabled='true']:opacity-50
 CommandItem.displayName = CommandPrimitive.Item.displayName;
 
 const CommandShortcut = ({

--- a/apps/web/src/components/shared/ProfileButton.tsx
+++ b/apps/web/src/components/shared/ProfileButton.tsx
@@ -164,7 +164,7 @@ export default async function ProfileButton() {
 					{user.role === "admin" ||
 						(user.role === "super_admin" && (
 							<Link href={`/admin`}>
-								<DropdownMenuItem className="cursor-pointer hover:!bg-amber-600">
+								<DropdownMenuItem className="cursor-pointer text-hackathon">
 									Admin
 								</DropdownMenuItem>
 							</Link>


### PR DESCRIPTION
## Why
The blob upload currently puts all of the hackathon uploads into one, top-level, unorganized folder. This can be highly improved upon. While working to make this change, an unavoidable blocker occurred from our UI library that had to be fixed.
Before this PR, upgrading our UI library, shadCn, came with required updates to part of the registration form's Command Input. With upgrades to [cmdk](https://www.npmjs.com/package/cmdk) which is a library Shad uses for the Command components, it required the _CommandGroup_ to be wrapped in a _CommandList_ component. 

## What

- Updated the file path so that resumes will upload to `/hackathon_name/resume/name_of_upload`
- Updated the Command Input to the appropriate styling 
- Fixed the _Admin_ dropdown link to be the same blue as the hackathon background so it would stand out more

## Satisfies
HK-145 (#82)
HK-146 (#83)