### PR TITLE
Fix Hackathon Check-In Scanner

### DIFF
--- a/apps/web/src/actions/admin/scanner-admin-actions.ts
+++ b/apps/web/src/actions/admin/scanner-admin-actions.ts
@@ -69,15 +69,14 @@ export const checkInUserToHackathon = adminAction
 	.schema(z.string())
 	.action(async ({ parsedInput: user }) => {
 		// Set checkinTimestamp
-		try{
+		try {
 			await db
-			.update(userCommonData)
-			.set({ checkinTimestamp: sql`now()` })
-			.where(eq(userCommonData.clerkID, user));
-		}
-		catch(e){
-			console.log('Error updating checkinTimestamp: ', e);
-			return { success: false, message: 'Error checking in the user!' };
+				.update(userCommonData)
+				.set({ checkinTimestamp: sql`now()` })
+				.where(eq(userCommonData.clerkID, user));
+		} catch (e) {
+			console.log("Error updating checkinTimestamp: ", e);
+			return { success: false, message: "Error checking in the user!" };
 		}
 		return { success: true };
 	});

--- a/apps/web/src/actions/admin/scanner-admin-actions.ts
+++ b/apps/web/src/actions/admin/scanner-admin-actions.ts
@@ -68,7 +68,6 @@ export const getScan = adminAction
 export const checkInUserToHackathon = adminAction
 	.schema(z.string())
 	.action(async ({ parsedInput: user }) => {
-		console.log('Made to server. User is: ', user);
 		// Set checkinTimestamp
 		try{
 			await db

--- a/apps/web/src/actions/admin/scanner-admin-actions.ts
+++ b/apps/web/src/actions/admin/scanner-admin-actions.ts
@@ -6,7 +6,6 @@ import { db, sql } from "db";
 import { scans, userCommonData } from "db/schema";
 import { eq, and } from "db/drizzle";
 
-
 export const createScan = adminAction
 	.schema(
 		z.object({
@@ -69,19 +68,21 @@ export const getScan = adminAction
 
 // Schema will be moved over when rewrite of the other scanner happens
 const checkInUserSchema = z.object({
-	userID:z.string(),
-	QRTimestamp: z.number().positive().refine((timestamp) => {
-		return Date.now() - timestamp < 5 * 60 * 1000;
-		}, "QR Code has expired. Please refresh the QR Code"),
-})
+	userID: z.string(),
+	QRTimestamp: z
+		.number()
+		.positive()
+		.refine((timestamp) => {
+			return Date.now() - timestamp < 5 * 60 * 1000;
+		}, "QR Code has expired. Please tell user refresh the QR Code"),
+});
 
 export const checkInUserToHackathon = adminAction
 	.schema(checkInUserSchema)
-	.action(async ({ parsedInput: {userID} }) => {
+	.action(async ({ parsedInput: { userID } }) => {
 		// Set checkinTimestamp
-			await db
-				.update(userCommonData)
-				.set({ checkinTimestamp: sql`now()` })
-				.where(eq(userCommonData.clerkID, userID));
-		}
-	);
+		await db
+			.update(userCommonData)
+			.set({ checkinTimestamp: sql`now()` })
+			.where(eq(userCommonData.clerkID, userID));
+	});

--- a/apps/web/src/actions/admin/scanner-admin-actions.ts
+++ b/apps/web/src/actions/admin/scanner-admin-actions.ts
@@ -69,14 +69,9 @@ export const checkInUserToHackathon = adminAction
 	.schema(z.string())
 	.action(async ({ parsedInput: user }) => {
 		// Set checkinTimestamp
-		try {
 			await db
 				.update(userCommonData)
 				.set({ checkinTimestamp: sql`now()` })
 				.where(eq(userCommonData.clerkID, user));
-		} catch (e) {
-			console.log("Error updating checkinTimestamp: ", e);
-			return { success: false, message: "Error checking in the user!" };
 		}
-		return { success: true };
-	});
+	);

--- a/apps/web/src/actions/admin/scanner-admin-actions.ts
+++ b/apps/web/src/actions/admin/scanner-admin-actions.ts
@@ -65,12 +65,20 @@ export const getScan = adminAction
 		},
 	);
 
-export const checkInUser = adminAction
+export const checkInUserToHackathon = adminAction
 	.schema(z.string())
 	.action(async ({ parsedInput: user }) => {
+		console.log('Made to server. User is: ', user);
 		// Set checkinTimestamp
-		return await db
+		try{
+			await db
 			.update(userCommonData)
 			.set({ checkinTimestamp: sql`now()` })
 			.where(eq(userCommonData.clerkID, user));
+		}
+		catch(e){
+			console.log('Error updating checkinTimestamp: ', e);
+			return { success: false, message: 'Error checking in the user!' };
+		}
+		return { success: true };
 	});

--- a/apps/web/src/app/admin/check-in/page.tsx
+++ b/apps/web/src/app/admin/check-in/page.tsx
@@ -19,7 +19,9 @@ export default async function Page({
 		);
 
 	const scanUser = await getUser(searchParams.user);
-	if (!scanUser)
+	console.log(scanUser);
+	if (!scanUser){
+		console.log("no scan user found");
 		return (
 			<div>
 				<CheckinScanner
@@ -30,7 +32,9 @@ export default async function Page({
 				/>
 			</div>
 		);
-
+	}
+		
+	console.log('using scanner case instead')
 	return (
 		<div>
 			<CheckinScanner

--- a/apps/web/src/app/admin/check-in/page.tsx
+++ b/apps/web/src/app/admin/check-in/page.tsx
@@ -20,7 +20,7 @@ export default async function Page({
 
 	const scanUser = await getUser(searchParams.user);
 	console.log(scanUser);
-	if (!scanUser){
+	if (!scanUser) {
 		return (
 			<div>
 				<CheckinScanner
@@ -32,7 +32,7 @@ export default async function Page({
 			</div>
 		);
 	}
-		
+
 	return (
 		<div>
 			<CheckinScanner

--- a/apps/web/src/app/admin/check-in/page.tsx
+++ b/apps/web/src/app/admin/check-in/page.tsx
@@ -21,7 +21,6 @@ export default async function Page({
 	const scanUser = await getUser(searchParams.user);
 	console.log(scanUser);
 	if (!scanUser){
-		console.log("no scan user found");
 		return (
 			<div>
 				<CheckinScanner
@@ -34,7 +33,6 @@ export default async function Page({
 		);
 	}
 		
-	console.log('using scanner case instead')
 	return (
 		<div>
 			<CheckinScanner

--- a/apps/web/src/components/admin/scanner/CheckinScanner.tsx
+++ b/apps/web/src/components/admin/scanner/CheckinScanner.tsx
@@ -34,8 +34,7 @@ export default function CheckinScanner({
 	scanUser,
 	hasRSVP,
 }: CheckinScannerProps) {
-
-	console.log('scanner props is: ',hasScanned, checkedIn, scanUser, hasRSVP)
+	console.log("scanner props is: ", hasScanned, checkedIn, scanUser, hasRSVP);
 
 	const [scanLoading, setScanLoading] = useState(false);
 	useEffect(() => {
@@ -48,14 +47,20 @@ export default function CheckinScanner({
 	const path = usePathname();
 	const router = useRouter();
 
-	const {  execute:runCheckInUserToHackathon, result:checkInResult} = useAction(checkInUserToHackathon);
+	const { execute: runCheckInUserToHackathon, result: checkInResult } =
+		useAction(checkInUserToHackathon);
 
 	useEffect(() => {
-		if (checkInResult && checkInResult.data && !checkInResult.data.success){
-			alert(`${checkInResult.data?.message ?? 'Error checking in user To the hackathon'}`);
+		if (
+			checkInResult &&
+			checkInResult.data &&
+			!checkInResult.data.success
+		) {
+			alert(
+				`${checkInResult.data?.message ?? "Error checking in user To the hackathon"}`,
+			);
 		}
-
-	},[checkInResult]);
+	}, [checkInResult]);
 	function handleScanCreate() {
 		const params = new URLSearchParams(searchParams.toString());
 		const timestamp = parseInt(params.get("createdAt") as string);
@@ -71,23 +76,25 @@ export default function CheckinScanner({
 			return alert("User Already Checked in!");
 		} else {
 			runCheckInUserToHackathon(scanUser.clerkID);
-			
 		}
 		toast.success("Successfully Scanned User In");
 		router.replace(`${path}`);
 	}
 
-	const drawerTitle = checkedIn 
-			? "User Already Checked In" 
-			: !hasRSVP ? 'Warning!'
+	const drawerTitle = checkedIn
+		? "User Already Checked In"
+		: !hasRSVP
+			? "Warning!"
 			: "New Scan";
-	const drawerDescription = checkedIn 
-			? 'If this is a mistake, please talk to an admin' 
-			: !hasRSVP ? `${scanUser?.firstName} ${scanUser?.lastName} Is not RSVP'd`
+	const drawerDescription = checkedIn
+		? "If this is a mistake, please talk to an admin"
+		: !hasRSVP
+			? `${scanUser?.firstName} ${scanUser?.lastName} Is not RSVP'd`
 			: `New scan for ${scanUser?.firstName} ${scanUser?.lastName}`;
-	const drawerFooterButtonText = checkedIn 
-			? "Close" 
-			: !hasRSVP ? "Check In Anyways"
+	const drawerFooterButtonText = checkedIn
+		? "Close"
+		: !hasRSVP
+			? "Check In Anyways"
 			: "Scan User In";
 
 	return (
@@ -130,7 +137,8 @@ export default function CheckinScanner({
 			</div>
 			<Drawer
 				onClose={() => router.replace(path)}
-				open={hasScanned || scanLoading}>
+				open={hasScanned || scanLoading}
+			>
 				<DrawerContent>
 					{scanLoading ? (
 						<>
@@ -140,7 +148,8 @@ export default function CheckinScanner({
 							<DrawerFooter>
 								<Button
 									onClick={() => router.replace(path)}
-									variant="outline">
+									variant="outline"
+								>
 									Cancel
 								</Button>
 							</DrawerFooter>
@@ -151,7 +160,8 @@ export default function CheckinScanner({
 								<DrawerTitle
 									className={clsx("mx-auto", {
 										"text-red-500": !hasRSVP || checkedIn,
-									})}>
+									})}
+								>
 									{drawerTitle}
 								</DrawerTitle>
 							</DrawerHeader>
@@ -160,7 +170,9 @@ export default function CheckinScanner({
 							</DrawerDescription>
 							<DrawerFooter>
 								{!hasRSVP && !checkedIn && (
-									<div className="mx-auto" >Do you wish to proceed?</div>
+									<div className="mx-auto">
+										Do you wish to proceed?
+									</div>
 								)}
 								{!checkedIn && (
 									<Button
@@ -174,7 +186,8 @@ export default function CheckinScanner({
 								)}
 								<Button
 									onClick={() => router.replace(path)}
-									variant="outline">
+									variant="outline"
+								>
 									Cancel
 								</Button>
 							</DrawerFooter>

--- a/apps/web/src/components/admin/scanner/CheckinScanner.tsx
+++ b/apps/web/src/components/admin/scanner/CheckinScanner.tsx
@@ -47,20 +47,22 @@ export default function CheckinScanner({
 	const path = usePathname();
 	const router = useRouter();
 
-	const { execute: runCheckInUserToHackathon, result: checkInResult } =
-		useAction(checkInUserToHackathon);
+	function handleUseActionFeedback(hasErrored = false) {
+		toast.dismiss();
+		(hasErrored) ? toast.error("Failed to Check User Into Hackathon") : toast.success("Successfully Checked User Into Hackathon!");
+		router.replace(`${path}`);
+	}
 
-	useEffect(() => {
-		if (
-			checkInResult &&
-			checkInResult.data &&
-			!checkInResult.data.success
-		) {
-			alert(
-				`${checkInResult.data?.message ?? "Error checking in user To the hackathon"}`,
-			);
-		}
-	}, [checkInResult]);
+	const { execute: runCheckInUserToHackathon, result: checkInResult } =
+		useAction(checkInUserToHackathon,{
+			onSuccess: () => {
+				handleUseActionFeedback();
+			},
+			onError: () =>{
+				handleUseActionFeedback(true);
+			}
+		});
+
 	function handleScanCreate() {
 		const params = new URLSearchParams(searchParams.toString());
 		const timestamp = parseInt(params.get("createdAt") as string);
@@ -75,10 +77,10 @@ export default function CheckinScanner({
 		if (checkedIn) {
 			return alert("User Already Checked in!");
 		} else {
+			toast.loading('Checking User In');
 			runCheckInUserToHackathon(scanUser.clerkID);
 		}
-		toast.success("Successfully Scanned User In");
-		router.replace(`${path}`);
+		router.replace(path);
 	}
 
 	const drawerTitle = checkedIn

--- a/apps/web/src/components/admin/scanner/CheckinScanner.tsx
+++ b/apps/web/src/components/admin/scanner/CheckinScanner.tsx
@@ -48,31 +48,37 @@ export default function CheckinScanner({
 	const path = usePathname();
 	const router = useRouter();
 
-	function handleUseActionFeedback(hasErrored=false,message="") {
+	function handleUseActionFeedback(hasErrored = false, message = "") {
 		console.log("called");
 		toast.dismiss();
 		hasErrored
 			? toast.error(message || "Failed to Check User Into Hackathon")
-			: toast.success(message || "Successfully Checked User Into Hackathon!");
+			: toast.success(
+					message || "Successfully Checked User Into Hackathon!",
+				);
 		router.replace(`${path}`);
 	}
 
-	const { execute: runCheckInUserToHackathon } =
-		useAction(checkInUserToHackathon, {
+	const { execute: runCheckInUserToHackathon } = useAction(
+		checkInUserToHackathon,
+		{
 			onSuccess: () => {
 				handleUseActionFeedback();
 			},
-			onError: ({error,input}) => {
+			onError: ({ error, input }) => {
 				console.log("error is: ", error);
 				console.log("input is: ", input);
-				if (error.validationErrors?.QRTimestamp?._errors){
-					handleUseActionFeedback(true,error.validationErrors.QRTimestamp._errors[0]);
-				}
-				else{
+				if (error.validationErrors?.QRTimestamp?._errors) {
+					handleUseActionFeedback(
+						true,
+						error.validationErrors.QRTimestamp._errors[0],
+					);
+				} else {
 					handleUseActionFeedback(true);
 				}
 			},
-		});
+		},
+	);
 
 	function handleScanCreate() {
 		const params = new URLSearchParams(searchParams.toString());
@@ -86,14 +92,19 @@ export default function CheckinScanner({
 			return alert("Invalid QR Code Data (Field: createdAt)");
 		}
 		if (Date.now() - timestamp > FIVE_MINUTES_IN_MILLISECONDS) {
-			return alert("QR Code has expired. Please refresh the QR Code");
+			return alert(
+				"QR Code has expired. Please tell user to refresh the QR Code",
+			);
 		}
 
 		if (checkedIn) {
 			return alert("User Already Checked in!");
 		} else {
 			toast.loading("Checking User In");
-			runCheckInUserToHackathon({userID:scanUser.clerkID, QRTimestamp: timestamp});
+			runCheckInUserToHackathon({
+				userID: scanUser.clerkID,
+				QRTimestamp: timestamp,
+			});
 		}
 		router.replace(path);
 	}

--- a/apps/web/src/components/shared/ProfileButton.tsx
+++ b/apps/web/src/components/shared/ProfileButton.tsx
@@ -19,6 +19,7 @@ import { DropdownSwitcher } from "@/components/shared/ThemeSwitcher";
 import DefaultDropdownTrigger from "../dash/shared/DefaultDropDownTrigger";
 import MobileNavBarLinks from "./MobileNavBarLinks";
 import { getUser } from "db/functions";
+import { redirect } from "next/navigation";
 
 export default async function ProfileButton() {
 	const clerkUser = await auth();

--- a/apps/web/src/lib/constants/index.ts
+++ b/apps/web/src/lib/constants/index.ts
@@ -1,2 +1,3 @@
 export const ONE_HOUR_IN_MILLISECONDS = 3600000;
+export const FIVE_MINUTES_IN_MILLISECONDS = 300000;
 export const VERCEL_IP_TIMEZONE_HEADER_KEY = "x-vercel-ip-timezone";

--- a/packages/config/hackkit.config.ts
+++ b/packages/config/hackkit.config.ts
@@ -852,7 +852,7 @@ const c = {
 			Users: "/admin/users",
 			Events: "/admin/events",
 			Points: "/admin/points",
-			"Check-in": "/admin/check-in",
+			"Hackathon Check-in": "/admin/check-in",
 			Toggles: "/admin/toggles",
 		},
 		// TODO: Can remove days? Pretty sure they're dynamic now.


### PR DESCRIPTION
## Why
The logic for the hackathon check-in scanner was claiming that users were not RSVP'd when they, in fact, were. Furthermore, the code for the scanner was messy and hard to follow with sometimes nested ternary rendering logic.

## What
- Rewrote the logic for the scanner to use the props passed in from the server component as the single source of truth
- Used the `useAction` hook for taking care of handling success and error state
- Further leveraged the toasts for giving loading, success, and error states
- Added check to ensure users do not screenshot or use someone else's QR code by implementing both a client and server-side check to ensure no QR code is older than 5 minutes
- Refactored the QR scanner code to be much cleaner to read and removed ternary rendering logic.
- Rename the admin tab from "check-in" to "hackathon check-in"
- Other small quality-of-life features

## Satisfies 
[HK-174 ](https://linear.app/acmutsa/issue/HK-174/fix-qr-scanner)(#127 )