### PR TITLE
Generate Missing Migrations File

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prettier": "^3.3.3",
     "turbo": "^2.0.9"
   },
-  "packageManager": "pnpm@8.3.1",
+  "packageManager": "pnpm@8.3.1+sha512.d264f6640bf4f09de7cfcc547568515bcf0613cf485a03e8ff16616fa69c4172b6f9a0a2925ee44fb060df565c9c9a8eaf061749e77af318cb77f6684a7051f3",
   "name": "hackkit",
   "dependencies": {
     "prettier-plugin-tailwindcss": "^0.6.5"

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1726078325574,
       "tag": "0018_melodic_starbolt",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1731962141317,
+      "tag": "0019_blue_robbie_robertson",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## What
Run `pnpm run migrations:generate` and push generated migration files

## Why
Migrations missing from the repo

## Satisfies
- Missing Drizzle Migrations (#134)(HK-178)