### PR TITLE
Adds extra validation for rsvps

### DIFF
--- a/apps/web/src/actions/admin/registration-actions.ts
+++ b/apps/web/src/actions/admin/registration-actions.ts
@@ -9,6 +9,10 @@ const defaultRegistrationToggleSchema = z.object({
 	enabled: z.boolean(),
 });
 
+const defaultRSVPLimitSchema = z.object({
+	rsvpLimit: z.number(),
+});
+
 export const toggleRegistrationEnabled = adminAction
 	.schema(defaultRegistrationToggleSchema)
 	.action(async ({ parsedInput: { enabled }, ctx: { user, userId } }) => {
@@ -39,4 +43,12 @@ export const toggleRSVPs = adminAction
 		await kv.set("config:registration:allowRSVPs", enabled);
 		revalidatePath("/admin/toggles/registration");
 		return { success: true, statusSet: enabled };
+	});
+
+export const setRSVPLimit = adminAction
+	.schema(defaultRSVPLimitSchema)
+	.action(async ({ parsedInput: { rsvpLimit }, ctx: { user, userId } }) => {
+		await kv.set("config:registration:maxRSVPs", rsvpLimit);
+		revalidatePath("/admin/toggles/registration");
+		return { success: true, statusSet: rsvpLimit };
 	});

--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -39,10 +39,7 @@ export default async function AdminLayout({ children }: AdminLayoutProps) {
 			<ClientToast />
 			<div className="fixed z-20 grid h-16 w-full grid-cols-2 bg-nav px-5">
 				<div className="flex items-center gap-x-4">
-					<Link 
-						href={"/"}
-						className="mr-5 flex items-center gap-x-2"
-					>
+					<Link href={"/"} className="mr-5 flex items-center gap-x-2">
 						<Image
 							src={c.icon.svg}
 							alt={c.hackathonName + " Logo"}

--- a/apps/web/src/app/admin/toggles/registration/page.tsx
+++ b/apps/web/src/app/admin/toggles/registration/page.tsx
@@ -1,6 +1,7 @@
 import { RegistrationToggles } from "@/components/admin/toggles/RegistrationSettings";
 import { kv } from "@vercel/kv";
-import { parseRedisBoolean } from "@/lib/utils/server/redis";
+import { parseRedisBoolean, parseRedisNumber } from "@/lib/utils/server/redis";
+import c from "config";
 
 export default async function Page() {
 	const pipe = kv.pipeline();
@@ -8,14 +9,14 @@ export default async function Page() {
 	pipe.get("config:registration:secretRegistrationEnabled");
 	// const result = await pipe.exec();
 
-	const [
-		defaultRegistrationEnabled,
-		defaultSecretRegistrationEnabled,
-		defaultRSVPsEnabled,
-	]: (string | null)[] = await kv.mget(
+	const [defaultRegistrationEnabled, defaultSecretRegistrationEnabled, defaultRSVPsEnabled, defaultRSVPLimit]: (
+		| string
+		| null
+	)[] = await kv.mget(
 		"config:registration:registrationEnabled",
 		"config:registration:secretRegistrationEnabled",
 		"config:registration:allowRSVPs",
+		"config:registration:maxRSVPs"
 	);
 
 	return (
@@ -37,6 +38,10 @@ export default async function Page() {
 				defaultRSVPsEnabled={parseRedisBoolean(
 					defaultRSVPsEnabled,
 					true,
+				)}
+				defaultRSVPLimit={parseRedisNumber(
+					defaultRSVPLimit,
+					c.rsvpDefaultLimit
 				)}
 			/>
 		</div>

--- a/apps/web/src/app/admin/toggles/registration/page.tsx
+++ b/apps/web/src/app/admin/toggles/registration/page.tsx
@@ -9,14 +9,16 @@ export default async function Page() {
 	pipe.get("config:registration:secretRegistrationEnabled");
 	// const result = await pipe.exec();
 
-	const [defaultRegistrationEnabled, defaultSecretRegistrationEnabled, defaultRSVPsEnabled, defaultRSVPLimit]: (
-		| string
-		| null
-	)[] = await kv.mget(
+	const [
+		defaultRegistrationEnabled,
+		defaultSecretRegistrationEnabled,
+		defaultRSVPsEnabled,
+		defaultRSVPLimit,
+	]: (string | null)[] = await kv.mget(
 		"config:registration:registrationEnabled",
 		"config:registration:secretRegistrationEnabled",
 		"config:registration:allowRSVPs",
-		"config:registration:maxRSVPs"
+		"config:registration:maxRSVPs",
 	);
 
 	return (
@@ -41,7 +43,7 @@ export default async function Page() {
 				)}
 				defaultRSVPLimit={parseRedisNumber(
 					defaultRSVPLimit,
-					c.rsvpDefaultLimit
+					c.rsvpDefaultLimit,
 				)}
 			/>
 		</div>

--- a/apps/web/src/app/rsvp/page.tsx
+++ b/apps/web/src/app/rsvp/page.tsx
@@ -2,13 +2,13 @@ import ConfirmDialogue from "@/components/rsvp/ConfirmDialogue";
 import c from "config";
 import { auth } from "@clerk/nextjs";
 import { redirect } from "next/navigation";
-import { db } from "db";
+import { count, db } from "db";
 import { eq } from "db/drizzle";
 import { userCommonData } from "db/schema";
 import ClientToast from "@/components/shared/ClientToast";
 import { SignedOut, RedirectToSignIn } from "@clerk/nextjs";
 import { kv } from "@vercel/kv";
-import { parseRedisBoolean } from "@/lib/utils/server/redis";
+import { parseRedisBoolean, parseRedisNumber } from "@/lib/utils/server/redis";
 import Link from "next/link";
 import { Button } from "@/components/shadcn/ui/button";
 import { getUser } from "db/functions";
@@ -41,15 +41,25 @@ export default async function RsvpPage({
 	}
 
 	const rsvpEnabled = await kv.get("config:registration:allowRSVPs");
+	const rsvpLimit = parseRedisNumber(
+		await kv.get("config:registration:maxRSVPs"),
+		c.rsvpDefaultLimit,
+	);
+	const rsvpUserCount = await db
+		.select({ count: count() })
+		.from(userCommonData)
+		.where(eq(userCommonData.isRSVPed, true))
+		.limit(rsvpLimit)
+		.then((result) => result[0].count);
 
 	// TODO: fix type jank here
-	if (
+	const isRsvpPossible =
 		parseRedisBoolean(
 			rsvpEnabled as string | boolean | null | undefined,
 			true,
-		) === true ||
-		user.isRSVPed === true
-	) {
+		) === true && rsvpUserCount < rsvpLimit;
+
+	if (isRsvpPossible || user.isRSVPed === true) {
 		return (
 			<>
 				<ClientToast />

--- a/apps/web/src/app/rsvp/page.tsx
+++ b/apps/web/src/app/rsvp/page.tsx
@@ -40,24 +40,28 @@ export default async function RsvpPage({
 		return redirect("/i/approval");
 	}
 
-	const rsvpEnabled = await kv.get("config:registration:allowRSVPs");
-	const rsvpLimit = parseRedisNumber(
-		await kv.get("config:registration:maxRSVPs"),
-		c.rsvpDefaultLimit,
+	const rsvpEnabled = parseRedisBoolean(
+		await kv.get("config:registration:allowRSVPs") as string | boolean | null | undefined,
+		true,
 	);
-	const rsvpUserCount = await db
-		.select({ count: count() })
-		.from(userCommonData)
-		.where(eq(userCommonData.isRSVPed, true))
-		.limit(rsvpLimit)
-		.then((result) => result[0].count);
 
-	// TODO: fix type jank here
-	const isRsvpPossible =
-		parseRedisBoolean(
-			rsvpEnabled as string | boolean | null | undefined,
-			true,
-		) === true && rsvpUserCount < rsvpLimit;
+	let isRsvpPossible = false;
+
+	if (rsvpEnabled === true) {
+		const rsvpLimit = parseRedisNumber(
+			await kv.get("config:registration:maxRSVPs"),
+			c.rsvpDefaultLimit,
+		);
+
+		const rsvpUserCount = await db
+			.select({ count: count() })
+			.from(userCommonData)
+			.where(eq(userCommonData.isRSVPed, true))
+			.limit(rsvpLimit)
+			.then((result) => result[0].count);
+
+		isRsvpPossible = rsvpUserCount < rsvpLimit;
+	}
 
 	if (isRsvpPossible || user.isRSVPed === true) {
 		return (

--- a/apps/web/src/app/rsvp/page.tsx
+++ b/apps/web/src/app/rsvp/page.tsx
@@ -41,7 +41,11 @@ export default async function RsvpPage({
 	}
 
 	const rsvpEnabled = parseRedisBoolean(
-		await kv.get("config:registration:allowRSVPs") as string | boolean | null | undefined,
+		(await kv.get("config:registration:allowRSVPs")) as
+			| string
+			| boolean
+			| null
+			| undefined,
 		true,
 	);
 

--- a/apps/web/src/components/admin/toggles/RegistrationSettings.tsx
+++ b/apps/web/src/components/admin/toggles/RegistrationSettings.tsx
@@ -11,18 +11,22 @@ import {
 	toggleRegistrationMessageEnabled,
 	toggleSecretRegistrationEnabled,
 	toggleRSVPs,
+	setRSVPLimit,
 } from "@/actions/admin/registration-actions";
+import { UpdateItemWithConfirmation } from "./UpdateItemWithConfirmation";
 
 interface RegistrationTogglesProps {
 	defaultRegistrationEnabled: boolean;
 	defaultSecretRegistrationEnabled: boolean;
 	defaultRSVPsEnabled: boolean;
+	defaultRSVPLimit: number;
 }
 
 export function RegistrationToggles({
 	defaultSecretRegistrationEnabled,
 	defaultRegistrationEnabled,
 	defaultRSVPsEnabled,
+	defaultRSVPLimit,
 }: RegistrationTogglesProps) {
 	const {
 		execute: executeToggleSecretRegistrationEnabled,
@@ -54,6 +58,16 @@ export function RegistrationToggles({
 		currentState: { success: true, statusSet: defaultRegistrationEnabled },
 		updateFn: (state, { enabled }) => {
 			return { statusSet: enabled, success: true };
+		},
+	});
+
+	const {
+		execute: executeSetRSVPLimit,
+		optimisticState: SetRSVPLimitOptimisticData,
+	} = useOptimisticAction(setRSVPLimit, {
+		currentState: { success: true, statusSet: defaultRSVPLimit },
+		updateFn: (state, { rsvpLimit }) => {
+			return { statusSet: rsvpLimit, success: true };
 		},
 	});
 
@@ -113,6 +127,20 @@ export function RegistrationToggles({
 									`RSVPs ${checked ? "enabled" : "disabled"} successfully!`,
 								);
 								executeToggleRSVPs({ enabled: checked });
+							}}
+						/>
+					</div>
+					<div className="flex items-center border-b border-t border-t-muted py-4">
+						<p className="mr-auto text-sm font-bold">RSVP Limit</p>
+						<UpdateItemWithConfirmation
+							defaultValue={SetRSVPLimitOptimisticData.statusSet}
+							enabled={toggleRSVPsOptimisticData.statusSet}
+							type="number"
+							onSubmit={(newLimit) => {
+								toast.success(
+									`Hacker RSVP limit successfully changed to ${newLimit}!`,
+								);
+								executeSetRSVPLimit({ rsvpLimit: newLimit });
 							}}
 						/>
 					</div>

--- a/apps/web/src/components/admin/toggles/UpdateItemWithConfirmation.tsx
+++ b/apps/web/src/components/admin/toggles/UpdateItemWithConfirmation.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import { Input } from "@/components/shadcn/ui/input";
+import { Button } from "@/components/shadcn/ui/button";
+
+interface UpdateItemWithConfirmationBaseProps<T extends number | string> {
+	defaultValue: T;
+	enabled: boolean;
+	onSubmit: (value: T) => void;
+}
+
+type UpdateItemWithConfirmationProps =
+	| ({ type: "string" } & UpdateItemWithConfirmationBaseProps<string>)
+	| ({ type: "number" } & UpdateItemWithConfirmationBaseProps<number>);
+
+export function UpdateItemWithConfirmation({
+	type,
+	defaultValue,
+	onSubmit,
+	enabled,
+}: UpdateItemWithConfirmationProps) {
+	const [valueUpdated, setValueUpdated] = useState(false);
+	const [value, setValue] = useState(defaultValue.toString());
+
+	return (
+		<div className="flex items-center gap-2 max-h-8">
+			<Input
+				className="sm:w-40 w-24 text-center text-md font-bold"
+				value={value}
+				disabled={!enabled}
+				onChange={({ target: { value: updated } }) => {
+					// Ignore the change if the value is a non numeric character.
+					if (type === "number" && /[^0-9]/.test(updated)) {
+						setValue(value);
+						return;
+					}
+
+					setValue(updated);
+
+					/* Avoid allowing the user to update the default value to itself.
+					 * Also disallow the user from sending a zero length input. */
+					setValueUpdated(
+						updated !== defaultValue.toString() && updated.length !== 0
+					);
+				}}
+			/>
+			<Button
+				className="text-sm font-bold"
+				type="button"
+				variant="default"
+				title="Apply Changes"
+				disabled={!valueUpdated || !enabled}
+				onClick={() => {
+					if (type === "number") {
+						onSubmit(parseInt(value));
+					} else {
+						onSubmit(value);
+					}
+
+					setValueUpdated(false);
+				}}
+			>
+				Apply
+			</Button>
+		</div>
+	);
+}

--- a/apps/web/src/components/admin/toggles/UpdateItemWithConfirmation.tsx
+++ b/apps/web/src/components/admin/toggles/UpdateItemWithConfirmation.tsx
@@ -22,9 +22,9 @@ export function UpdateItemWithConfirmation({
 	const [value, setValue] = useState(defaultValue.toString());
 
 	return (
-		<div className="flex items-center gap-2 max-h-8">
+		<div className="flex max-h-8 items-center gap-2">
 			<Input
-				className="sm:w-40 w-24 text-center text-md font-bold"
+				className="text-md w-24 text-center font-bold sm:w-40"
 				value={value}
 				disabled={!enabled}
 				onChange={({ target: { value: updated } }) => {
@@ -39,7 +39,8 @@ export function UpdateItemWithConfirmation({
 					/* Avoid allowing the user to update the default value to itself.
 					 * Also disallow the user from sending a zero length input. */
 					setValueUpdated(
-						updated !== defaultValue.toString() && updated.length !== 0
+						updated !== defaultValue.toString() &&
+							updated.length !== 0,
 					);
 				}}
 			/>

--- a/apps/web/src/lib/utils/client/shared.ts
+++ b/apps/web/src/lib/utils/client/shared.ts
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 export function getClientTimeZone(vercelIPTimeZone: string | null) {
 	return vercelIPTimeZone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
 }
-export async function clientLogOut(){
-		"use server";
-		redirect("/");
-};
+export async function clientLogOut() {
+	"use server";
+	redirect("/");
+}

--- a/apps/web/src/lib/utils/server/redis.ts
+++ b/apps/web/src/lib/utils/server/redis.ts
@@ -31,3 +31,11 @@ export function parseRedisBoolean(
 	if (typeof value === "boolean") return value;
 	return defaultValue !== undefined ? defaultValue : false;
 }
+
+export function parseRedisNumber(value: string | null, defaultValue: number) {
+	if (value && !isNaN(parseInt(value))) {
+		return parseInt(value);
+	} else {
+		return defaultValue;
+	}
+}

--- a/packages/config/hackkit.config.ts
+++ b/packages/config/hackkit.config.ts
@@ -778,6 +778,7 @@ const c = {
 	itteration: "I",
 	siteUrl: "https://rowdyhacks.org", // Do not have a trailing slash
 	defaultMetaDataDescription: "Your Metadata Description Here",
+	rsvpDefaultLimit: 500,
 	botName: "HackKit",
 	botParticipantRole: "Participant",
 	hackathonTimezone: "America/Chicago",


### PR DESCRIPTION
# Why
Users of hackkit wanted a way to set a limit on the number of RSVPs that are allowed for hackathons.
# What
- Created an admin action that uses vercel KV to store the current limit of RSVPs.
- Created an input in the admin dashboard that allows admins to change the limit of users who can RSVP
- Added a default limit inside of the hackkit configuration file
- Added a check against the number of RSVP'd users whenever a hacker tries to rsvp
# Satisfies
#49
https://linear.app/acmutsa/issue/HK-123/add-extra-validation-for-rsvps