### PR TITLE
Adds listing of skills to user view on admin panel

### DIFF
--- a/apps/web/src/components/admin/users/ServerSections.tsx
+++ b/apps/web/src/components/admin/users/ServerSections.tsx
@@ -49,7 +49,14 @@ export function ProfileInfo({ user }: { user: Hacker }) {
 				/>
 			</div>
 			<div className="flex flex-col gap-y-5 pt-5">
-				<Cell title="Skills" value={"Coming soon..."} />
+				<Cell
+					title="Skills"
+					value={
+						user.skills && (user.skills as string[]).length > 0
+							? (user.skills as string[]).join(", ")
+							: ""
+					}
+				/>
 				<Cell title="Bio" value={user.bio} />
 			</div>
 		</UserInfoSection>


### PR DESCRIPTION
# Why
Currently there is no user skill listing for users in admin panel
# What
Adds listing of user skills for admin panel
# Satisfies
https://linear.app/acmutsa/issue/HK-176/adds-listing-of-skills-to-user-view-on-admin-panel
(Not sure if there is a GH issue for this either)