### PR TITLE
Adds ability for admins to edit navigation toggles

### DIFF
--- a/apps/web/src/app/admin/toggles/landing/page.tsx
+++ b/apps/web/src/app/admin/toggles/landing/page.tsx
@@ -1,6 +1,6 @@
 import {
 	NavItemsManager,
-	NavItemDialog,
+	AddNavItemDialog,
 } from "@/components/admin/toggles/NavItemsManager";
 import { getAllNavItems } from "@/lib/utils/server/redis";
 
@@ -13,7 +13,7 @@ export default async function Page() {
 					Navbar Items
 				</h2>
 				<div className="ml-auto">
-					<NavItemDialog />
+					<AddNavItemDialog />
 				</div>
 			</div>
 			<NavItemsManager

--- a/apps/web/src/components/admin/toggles/NavItemsManager.tsx
+++ b/apps/web/src/components/admin/toggles/NavItemsManager.tsx
@@ -22,7 +22,7 @@ import {
 import { Button } from "@/components/shadcn/ui/button";
 import { Input } from "@/components/shadcn/ui/input";
 import { Label } from "@/components/shadcn/ui/label";
-import { Plus } from "lucide-react";
+import { Plus, Loader2 } from "lucide-react";
 import { useState } from "react";
 import { useAction, useOptimisticAction } from "next-safe-action/hooks";
 import {
@@ -91,6 +91,8 @@ export function NavItemsManager({ navItems }: NavItemsManagerProps) {
 								/>
 								<Button
 									onClick={() => {
+										toast.dismiss();
+										toast.loading("Deleting NavItem...");
 										execute(item.name);
 									}}
 								>
@@ -139,7 +141,11 @@ export function AddNavItemDialog() {
 	const [url, setUrl] = useState<string | null>(null);
 	const [open, setOpen] = useState(false);
 
-	const { execute, result, status } = useAction(setItem, {
+	const {
+		execute,
+		result,
+		status: createStatus,
+	} = useAction(setItem, {
 		onSuccess: () => {
 			console.log("Success");
 			setOpen(false);
@@ -149,6 +155,8 @@ export function AddNavItemDialog() {
 			toast.error("Error creating NavItem");
 		},
 	});
+
+	const isLoading = createStatus === "executing";
 
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
@@ -199,7 +207,12 @@ export function AddNavItemDialog() {
 							execute({ name, url });
 						}}
 					>
-						Create
+						{isLoading && (
+							<Loader2
+								className={"absolute z-50 h-4 w-4 animate-spin"}
+							/>
+						)}
+						<p className={`${isLoading && "invisible"}`}>Create</p>
 					</Button>
 				</DialogFooter>
 			</DialogContent>
@@ -222,7 +235,7 @@ function EditNavItemDialog({
 	const [url, setUrl] = useState<string>(existingUrl);
 	const [open, setOpen] = useState(false);
 
-	const { execute } = useAction(editItem, {
+	const { execute, status: editStatus } = useAction(editItem, {
 		onSuccess: () => {
 			console.log("Success");
 			setOpen(false);
@@ -232,6 +245,7 @@ function EditNavItemDialog({
 			toast.error("Error editing NavItem");
 		},
 	});
+	const isLoading = editStatus === "executing";
 
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
@@ -273,6 +287,7 @@ function EditNavItemDialog({
 				</div>
 				<DialogFooter>
 					<Button
+						className="relative"
 						onClick={() => {
 							console.log("Running Action");
 							if (!name || !url)
@@ -286,7 +301,12 @@ function EditNavItemDialog({
 							});
 						}}
 					>
-						Edit
+						{isLoading && (
+							<Loader2
+								className={"absolute z-50 h-4 w-4 animate-spin"}
+							/>
+						)}
+						<p className={`${isLoading && "invisible"}`}>Update</p>
 					</Button>
 				</DialogFooter>
 			</DialogContent>

--- a/apps/web/src/components/admin/toggles/NavItemsManager.tsx
+++ b/apps/web/src/components/admin/toggles/NavItemsManager.tsx
@@ -29,6 +29,7 @@ import {
 	setItem,
 	removeItem,
 	toggleItem,
+	editItem,
 } from "@/actions/admin/modify-nav-item";
 import { toast } from "sonner";
 import Link from "next/link";
@@ -42,6 +43,9 @@ export function NavItemsManager({ navItems }: NavItemsManagerProps) {
 	const { execute, result, status } = useAction(removeItem, {
 		onSuccess: () => {
 			toast.success("NavItem deleted successfully!");
+		},
+		onError: () => {
+			toast.error("Error deleting NavItem");
 		},
 	});
 
@@ -79,10 +83,12 @@ export function NavItemsManager({ navItems }: NavItemsManagerProps) {
 									name={item.name}
 								/>
 							</TableCell>
-							<TableCell className="space-x-2 text-right">
-								<Button onClick={() => alert("Coming soon...")}>
-									Edit
-								</Button>
+							<TableCell className="space-x-2 space-y-2 text-right">
+								<EditNavItemDialog
+									existingName={item.name}
+									existingUrl={item.url}
+									existingEnabled={item.enabled}
+								/>
 								<Button
 									onClick={() => {
 										execute(item.name);
@@ -113,6 +119,9 @@ function ToggleSwitch({
 		updateFn: (state, { statusToSet }) => {
 			return { itemStatus: statusToSet };
 		},
+		onError: () => {
+			toast.error("Error toggling NavItem");
+		},
 	});
 
 	return (
@@ -125,7 +134,7 @@ function ToggleSwitch({
 	);
 }
 
-export function NavItemDialog() {
+export function AddNavItemDialog() {
 	const [name, setName] = useState<string | null>(null);
 	const [url, setUrl] = useState<string | null>(null);
 	const [open, setOpen] = useState(false);
@@ -135,6 +144,9 @@ export function NavItemDialog() {
 			console.log("Success");
 			setOpen(false);
 			toast.success("NavItem created successfully!");
+		},
+		onError: () => {
+			toast.error("Error creating NavItem");
 		},
 	});
 
@@ -183,10 +195,98 @@ export function NavItemDialog() {
 							console.log("Running Action");
 							if (!name || !url)
 								return alert("Please fill out all fields.");
+
 							execute({ name, url });
 						}}
 					>
 						Create
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+interface EditNavItemDialogProps {
+	existingName: string;
+	existingUrl: string;
+	existingEnabled: boolean;
+}
+
+function EditNavItemDialog({
+	existingName,
+	existingUrl,
+	existingEnabled,
+}: EditNavItemDialogProps) {
+	const [name, setName] = useState<string>(existingName);
+	const [url, setUrl] = useState<string>(existingUrl);
+	const [open, setOpen] = useState(false);
+
+	const { execute } = useAction(editItem, {
+		onSuccess: () => {
+			console.log("Success");
+			setOpen(false);
+			toast.success("NavItem edited successfully!");
+		},
+		onError: () => {
+			toast.error("Error editing NavItem");
+		},
+	});
+
+	return (
+		<Dialog open={open} onOpenChange={setOpen}>
+			<DialogTrigger asChild>
+				<Button>Edit Item</Button>
+			</DialogTrigger>
+			<DialogContent className="sm:max-w-[425px]">
+				<DialogHeader>
+					<DialogTitle>Edit Item</DialogTitle>
+					<DialogDescription>
+						Edit an existing item shown in the non-dashboard navbar
+					</DialogDescription>
+				</DialogHeader>
+				<div className="grid gap-4 py-4">
+					<div className="grid grid-cols-4 items-center gap-4">
+						<Label htmlFor="name" className="text-right">
+							Name
+						</Label>
+						<Input
+							onChange={(e) => setName(e.target.value)}
+							id="name"
+							placeholder="A Cool Hyperlink"
+							className="col-span-3"
+							value={name}
+						/>
+					</div>
+					<div className="grid grid-cols-4 items-center gap-4">
+						<Label htmlFor="name" className="text-right">
+							URL
+						</Label>
+						<Input
+							onChange={(e) => setUrl(e.target.value)}
+							id="name"
+							placeholder="https://example.com/"
+							className="col-span-3"
+							value={url}
+						/>
+					</div>
+				</div>
+				<DialogFooter>
+					<Button
+						onClick={() => {
+							console.log("Running Action");
+							if (!name || !url)
+								return alert("Please fill out all fields.");
+
+							execute({
+								enabled: existingEnabled,
+								existingName,
+								name,
+								url,
+							});
+						}}
+					>
+						Edit
 					</Button>
 				</DialogFooter>
 			</DialogContent>

--- a/apps/web/src/components/admin/toggles/NavItemsManager.tsx
+++ b/apps/web/src/components/admin/toggles/NavItemsManager.tsx
@@ -42,9 +42,11 @@ interface NavItemsManagerProps {
 export function NavItemsManager({ navItems }: NavItemsManagerProps) {
 	const { execute, result, status } = useAction(removeItem, {
 		onSuccess: () => {
+			toast.dismiss();
 			toast.success("NavItem deleted successfully!");
 		},
 		onError: () => {
+			toast.dismiss();
 			toast.error("Error deleting NavItem");
 		},
 	});


### PR DESCRIPTION
# Why

Toggles currently have the option to be edited.  However, this functionality is not yet implemented.  Admins need a way to edit existing navigation links.

# What

- Added a new admin action that modifies an existing navigation item in KV.
- Added functionality for the edit button to present a dialog window for admins to edit the content of the navigation entry.
- Added toast to be displayed when a create/update/toggle/delete action fails.

### NOTE:
Does NOT implement optimistic updates for the navigation list.

# Satisfies
#90
https://linear.app/acmutsa/issue/HK-151/edit-toggles